### PR TITLE
Properties in result of Get-SCSMUserRole (which is called in Collect_…

### DIFF
--- a/SCSM-Diagnostic-Tool/SourceCode/_1_Collecting/Helper_Functions.ps1
+++ b/SCSM-Diagnostic-Tool/SourceCode/_1_Collecting/Helper_Functions.ps1
@@ -821,8 +821,12 @@ if (-not $noneWording) { $noneWording = "(none)" }
          #}
 
         ForEach ($item in $collection)
-        {            
-            $result +=  $separator + "$($item.DisplayName)"
+        {
+            $valueToDisplay = $item.DisplayName
+            if( $valueToDisplay.Trim().Length -eq 0 ) {
+                $valueToDisplay = $item.Id.ToString()
+            }
+            $result +=  $separator + $valueToDisplay
         }        
     }
     


### PR DESCRIPTION
…SCSMUserRoles()) can return empty values.

As an example, the View property is a collection and can contain items which DisplayName might be empty. Until now, in that case empty rows where written into Get-SCSMUserRole_WithAllDetails.csv. With this change, the Id property is written. As the item property is of type EnterpriseManagementObject, the Id property should always have a guid value.