### PR TITLE
collected Get-SmbClientConfiguration

### DIFF
--- a/SCSM-Diagnostic-Tool/SourceCode/_1_Collecting/Collect.ps1
+++ b/SCSM-Diagnostic-Tool/SourceCode/_1_Collecting/Collect.ps1
@@ -16,6 +16,7 @@ Write-Host "SCSM Diagnostic Tool started at $resultDateTime. (local time)"
 Write-Host "Please wait for completion. This can take a few minutes..." -ForegroundColor Yellow
 Write-Host "(Please ignore any Warning and Errors)"
 
+AppendOutputToFileInTargetFolder ( Get-SmbClientConfiguration ) Get-SmbClientConfiguration.txt
 CopyFileToTargetFolder $scriptFilePath
 AppendOutputToFileInTargetFolder ( $collectorVersion ) CollectorVersion.txt
 AppendOutputToFileInTargetFolder ( $ExecutionContext.SessionState.LanguageMode ) LanguageMode.txt

--- a/SCSM-Diagnostic-Tool/SourceCode/_2_Analyzing/Analyze.ps1
+++ b/SCSM-Diagnostic-Tool/SourceCode/_2_Analyzing/Analyze.ps1
@@ -80,6 +80,7 @@ $telemetry = GetEmptyTelemetryRow
     Start-Transcript -Path "$resultFolder\Transcript.txt" -NoClobber | Out-Null
     $startingDateTime = (Get-Date).ToString("yyyy-MM-dd__HH.mm.ss.fff")  
     Write-Host ""
+    AppendOutputToFileInTargetFolder ( Get-SmbClientConfiguration ) Get-SmbClientConfiguration.txt
     CopyFileToTargetFolder $scriptFilePath # -subFolderName $analyzer_FolderName
 
    AppendOutputToFileInTargetFolder  '"Duration","EndTime","StartTime","ScriptBlockText"'  Analyzer-MeasuredScriptBlocks.csv


### PR DESCRIPTION
because intermittently getting the error below while copying the currently running script into Analyzer folder.

PS>TerminatingError(Copy-Item): "The target file "C:\Users\xyz\Desktop\SCSM_DIAG_DW_2023-06-18__14.07.23.439\Analyzer" is a directory, not a file." Copy-Item : The target file "C:\Users\xyz\Desktop\SCSM_DIAG_DW_2023-06-18__14.07.23.439\Analyzer" is a directory, not a file.
At C:\Users\xyz\Desktop\SCSM-Diagnostic-Tool (1).ps1:3378 char:5
+     Copy-Item $fileName -Destination $resultFolder}
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Copy-Item], IOException
    + FullyQualifiedErrorId : System.IO.IOException,Microsoft.PowerShell.Commands.CopyItemCommand