### PR TITLE
Fixing System.Net.Http v4.2.0.0 issue

### DIFF
--- a/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.HealthStatus.Presentation/SCSM.Support.Tools.HealthStatus.Presentation.csproj
+++ b/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.HealthStatus.Presentation/SCSM.Support.Tools.HealthStatus.Presentation.csproj
@@ -89,7 +89,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.Library/SCSM.Support.Tools.Library.csproj
+++ b/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.Library/SCSM.Support.Tools.Library.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -63,13 +64,13 @@
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -97,6 +98,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Eula.rtf" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy $(TargetPath) $(ProjectDir)..\..\Output /Y</PostBuildEvent>

--- a/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.Main.Presentation/SCSM.Support.Tools.Main.Presentation.csproj
+++ b/SCSM.Support.Tools.mpb/MPResource/SCSM.Support.Tools.Main.Presentation/SCSM.Support.Tools.Main.Presentation.csproj
@@ -126,7 +126,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
forced to compile with v4.0.0.0 because resulting dll was crashing the Console were v4.2.0.0 did not exist.